### PR TITLE
Constraint composition

### DIFF
--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachDecimalMax.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachDecimalMax.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.DecimalMax;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.DecimalMax;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see DecimalMax
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachDecimalMax {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     DecimalMax[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachDecimalMin.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachDecimalMin.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.DecimalMin;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.DecimalMin;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see DecimalMin
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachDecimalMin {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     DecimalMin[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachDigits.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachDigits.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Digits;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Digits;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Digits
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachDigits {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Digits[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachFuture.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachFuture.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Future;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Future;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Future
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachFuture {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Future[] value() default @Future;

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachMax.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachMax.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Max;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Max;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Max
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachMax {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Max[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachMin.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachMin.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Min;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Min;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Min
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachMin {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Min[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPast.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPast.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Past;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Past;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Past
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPast {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Past[] value() default @Past;

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPattern.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPattern.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Pattern;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Pattern;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Pattern
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPattern {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Pattern[] value();

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachSize.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachSize.java
@@ -23,18 +23,20 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
-import cz.jirutka.validator.collection.CommonEachValidator;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
-import javax.validation.constraints.Size;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Size;
+
+import cz.jirutka.validator.collection.CommonEachValidator;
 
 /**
  * @see Size
@@ -42,12 +44,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD})
+@Target({ METHOD, FIELD, TYPE })
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachSize {
 
     String message() default "";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
     Size[] value();

--- a/src/test/java/cz/jirutka/validator/collection/constraint/CollectionElementsNotEmpty.java
+++ b/src/test/java/cz/jirutka/validator/collection/constraint/CollectionElementsNotEmpty.java
@@ -1,0 +1,34 @@
+package cz.jirutka.validator.collection.constraint;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import cz.jirutka.validator.collection.constraints.EachSize;
+
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {})
+@NotNull
+@EachSize(@Size(min = 1))
+public @interface CollectionElementsNotEmpty {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/cz/jirutka/validator/collection/constraint/CollectionElementsNotEmptyTest.java
+++ b/src/test/java/cz/jirutka/validator/collection/constraint/CollectionElementsNotEmptyTest.java
@@ -1,0 +1,38 @@
+package cz.jirutka.validator.collection.constraint;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.junit.Test;
+
+public class CollectionElementsNotEmptyTest {
+
+    @Test
+    public void test() throws Exception {
+	Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	List<String> data = new ArrayList<>();
+	data.add("one");
+	data.add("two");
+	TestClass testedObject = new TestClass(data);
+
+	assertEquals(0, validator.validateProperty(testedObject, "list").size());
+
+	testedObject.list.add("");
+	assertEquals(1, validator.validateProperty(testedObject, "list").size());
+    }
+
+    private static class TestClass {
+	@CollectionElementsNotEmpty
+	public List<String> list;
+
+	public TestClass(List<String> list) {
+	    this.list = list;
+	}
+    }
+}


### PR DESCRIPTION
Currently it is not possible to create a custom compound constraints annotation which contains one of the defined @Each.. annotations, because of the missing target type (java.lang.annotation.ElementType.TYPE).
This fix will allow re-using the @Each.. annotations in compound constraint annotations.
