### PR TITLE
Hibernate 6.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ env:
   global:
     secure: "KncKGamS99AWFQNs2L4a3s65BdNvP07yD/fulNZA+tsBNVLgxsieXkRdzrA5Efxbd5PvnBJuLkYgjPFSFh4uPNwijH5PnZMsSYlnSFIbLyGAIkWx2cJeUoDXOOrbHIeRmCDS6gZjs9sUZHrVlhF9B/19txf4XUjpd/6slqdsEng="  # BINTRAY_API_KEY
   matrix:
-    - HV_VERSION=4.3.2.Final
-    - HV_VERSION=5.0.3.Final DEPLOY=yes
-    - HV_VERSION=5.1.3.Final
-    - HV_VERSION=5.2.5.Final
-    - HV_VERSION=5.3.5.Final
-    - HV_VERSION=5.4.1.Final
-    - HV_VERSION=6.0.4.Final
+    - HV_GROUP_ID=org.hibernate HV_VERSION=4.3.2.Final
+    - HV_GROUP_ID=org.hibernate HV_VERSION=5.0.3.Final DEPLOY=yes
+    - HV_GROUP_ID=org.hibernate HV_VERSION=5.1.3.Final
+    - HV_GROUP_ID=org.hibernate HV_VERSION=5.2.5.Final
+    - HV_GROUP_ID=org.hibernate HV_VERSION=5.3.5.Final
+    - HV_GROUP_ID=org.hibernate HV_VERSION=5.4.1.Final
+    - HV_GROUP_ID=org.hibernate.validator HV_VERSION=6.0.0.Final
+    - HV_GROUP_ID=org.hibernate.validator HV_VERSION=6.0.3.Final
+    - HV_GROUP_ID=org.hibernate.validator HV_VERSION=6.0.4.Final
 
 # Cache local Maven repository
 cache:
@@ -22,9 +24,9 @@ before_cache:
   - rm -Rf ~/.m2/repository/cz/jirutka/validator/validator-collection
 
 install:
-  - mvn install -Ptest-different-hv-version -Dhv.version.test=${HV_VERSION} -DskipTests=true --batch-mode
+  - mvn install -Ptest-different-hv-version -Dhv.groupId.test=${HV_GROUP_ID} -Dhv.version.test=${HV_VERSION} -DskipTests=true --batch-mode
 script:
-  - mvn verify -Ptest-different-hv-version -Dhv.version.test=${HV_VERSION} --batch-mode
+  - mvn verify -Ptest-different-hv-version -Dhv.groupId.test=${HV_GROUP_ID} -Dhv.version.test=${HV_VERSION} --batch-mode
 after_success:
   - mvn jacoco:report coveralls:report
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - HV_VERSION=5.2.5.Final
     - HV_VERSION=5.3.5.Final
     - HV_VERSION=5.4.1.Final
+    - HV_VERSION=6.0.4.Final
 
 # Cache local Maven repository
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <!-- Note: Minimal supported version is 4.3.0.Final. -->
-            <version>5.4.1.Final</version>
+            <version>6.0.4.Final</version>
         </dependency>
 
         <dependency>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>2.2.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
     </issueManagement>
 
 
+    <!--//////////////////// PROPERTIES ////////////////////-->
+    <properties>
+        <!-- Note: Should be updated in parent pom. (Fixes Java 8 annotation target TYPE_USE in tests) -->
+        <groovy.version>2.4.15</groovy.version>
+    </properties>
+
+
     <!--//////////////////// DEPENDENCIES ////////////////////-->
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
     </issueManagement>
 
 
-    <!--//////////////////// PROPERTIES ////////////////////-->
-    <properties>
-        <!-- Note: Should be updated in parent pom. (Fixes Java 8 annotation target TYPE_USE in tests) -->
-        <groovy.version>2.4.15</groovy.version>
-    </properties>
-
-
     <!--//////////////////// DEPENDENCIES ////////////////////-->
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
 
     <!--//////////////////// PROPERTIES ////////////////////-->
     <properties>
-        <!-- Note: Should be updated in parent pom. (Fixes Java 8 annotation target TYPE_USE in tests) -->
         <groovy.version>2.4.15</groovy.version>
     </properties>
 
@@ -77,7 +76,7 @@
 
         <!-- JSR-349 Bean Validator -->
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <!-- Note: Minimal supported version is 4.3.0.Final. -->
             <version>6.0.4.Final</version>
@@ -147,7 +146,8 @@
             <id>test-different-hv-version</id>
 
             <properties>
-                <!-- Should be set from CLI: -Dhv.version.test=VERSION -->
+                <!-- Should be set from CLI: -Dhv.groupId.test=GROUP_ID -Dhv.version.test=VERSION -->
+                <hv.groupId.test></hv.groupId.test>
                 <hv.version.test></hv.version.test>
                 <dependency.directory>${project.build.directory}/dependency</dependency.directory>
             </properties>
@@ -165,7 +165,7 @@
                                     <outputDirectory>${dependency.directory}</outputDirectory>
                                     <artifactItems>
                                         <item>
-                                            <groupId>org.hibernate</groupId>
+                                            <groupId>${hv.groupId.test}</groupId>
                                             <artifactId>hibernate-validator</artifactId>
                                             <version>${hv.version.test}</version>
                                         </item>
@@ -180,6 +180,7 @@
                         <configuration>
                             <classpathDependencyExcludes>
                                 <exclude>org.hibernate:hibernate-validator</exclude>
+                                <exclude>org.hibernate.validator:hibernate-validator</exclude>
                             </classpathDependencyExcludes>
                             <additionalClasspathElements>
                                 <element>${dependency.directory}/hibernate-validator-${hv.version.test}.jar</element>

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachCodePointLength.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachCodePointLength.java
@@ -24,11 +24,11 @@
 package cz.jirutka.validator.collection.constraints;
 
 import cz.jirutka.validator.collection.CommonEachValidator;
+import org.hibernate.validator.constraints.CodePointLength;
+import org.hibernate.validator.constraints.CodePointLength.NormalizationStrategy;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,15 +37,16 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @since Hibernate Validator 6.0.3
+ * @see CodePointLength
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@EachConstraint(validateAs = CodePointLength.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachCodePointLength {
 
     String message() default "";
 
@@ -53,13 +54,9 @@ public @interface EachEmail {
 
     Class<? extends Payload>[] payload() default { };
 
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
+    int min() default 0;
 
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
+    int max() default Integer.MAX_VALUE;
+
+    NormalizationStrategy normalizationStrategy() default NormalizationStrategy.NONE;
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = Email.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachEmail {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
@@ -24,10 +24,10 @@
 package cz.jirutka.validator.collection.constraints;
 
 import cz.jirutka.validator.collection.CommonEachValidator;
+import org.hibernate.validator.constraints.Email;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachEmail.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = Email.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachEmail {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.FutureOrPresent;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see FutureOrPresent
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = FutureOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachFutureOrPresent {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = FutureOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachFutureOrPresent {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachFutureOrPresent.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = FutureOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachFutureOrPresent {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachMod11Check.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachMod11Check.java
@@ -55,7 +55,8 @@ public @interface EachMod11Check {
     Class<? extends Payload>[] payload() default { };
 
     /**
-     * @return The threshold for the Mod11 algorithm multiplier growth, if no value is specified the multiplier will grow indefinitely
+     * @return The threshold for the Mod11 algorithm multiplier growth, if no value is specified the multiplier will
+     * grow indefinitely
      */
     int threshold() default Integer.MAX_VALUE;
 
@@ -71,8 +72,8 @@ public @interface EachMod11Check {
 
     /**
      * @return The index of the check digit in the input. Per default it is assumed that the check digit is the last
-     * digit of the specified range. If set, the digit at the specified index is used. If set
-     * the following must hold true:<br/>
+     * digit of the specified range. If set, the digit at the specified index is used. If set the following must hold
+     * true:<br/>
      * {@code checkDigitIndex > 0 && (checkDigitIndex < startIndex || checkDigitIndex >= endIndex}.
      */
     int checkDigitIndex() default -1;
@@ -96,7 +97,8 @@ public @interface EachMod11Check {
     char treatCheck11As() default '0';
 
     /**
-     * @return Returns {@code RIGHT_TO_LEFT} if the Mod11 checksum must be done from the rightmost to the leftmost digit.
+     * @return Returns {@code RIGHT_TO_LEFT} if the Mod11 checksum must be done from the rightmost to the leftmost
+     * digit.
      * e.g. Code 12345-?:
      * <ul>
      * <li>{@code RIGHT_TO_LEFT} the sum (5*2 + 4*3 + 3*4 + 2*5 + 1*6) with check digit 5</li>

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Negative;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see Negative
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = Negative.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachNegative {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = Negative.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNegative {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegative.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = Negative.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNegative {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = NegativeOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNegativeOrZero {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = NegativeOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNegativeOrZero {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNegativeOrZero.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.NegativeOrZero;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see NegativeOrZero
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = NegativeOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachNegativeOrZero {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
@@ -23,9 +23,11 @@
  */
 package cz.jirutka.validator.collection.constraints;
 
+import cz.jirutka.validator.collection.CommonEachValidator;
+
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotEmpty;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -34,20 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see org.hibernate.validator.constraints.NotEmpty
+ * @see NotEmpty
+ * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE})
-@EachNotNull
-@EachSize(min = 1)
-@ReportAsSingleViolation
-@Constraint(validatedBy = { })
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@EachConstraint(validateAs = NotEmpty.class)
+@Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNotEmpty {
 
     String message() default "{org.hibernate.validator.constraints.NotEmpty.message}";
 
-    Class<?>[] groups() default { };
+    Class<?>[] groups() default {};
 
-    Class<? extends Payload>[] payload() default { };
+    Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
@@ -27,6 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.NotEmpty;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -42,8 +43,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = NotEmpty.class)
-@Constraint(validatedBy = CommonEachValidator.class)
+@EachNotNull
+@EachSize(min = 1)
+@ReportAsSingleViolation
+@Constraint(validatedBy = { })
 public @interface EachNotEmpty {
 
     String message() default "{org.hibernate.validator.constraints.NotEmpty.message}";

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = NotEmpty.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNotEmpty {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
@@ -51,7 +51,7 @@ public @interface EachNotEmpty {
 
     String message() default "{org.hibernate.validator.constraints.NotEmpty.message}";
 
-    Class<?>[] groups() default {};
+    Class<?>[] groups() default { };
 
-    Class<? extends Payload>[] payload() default {};
+    Class<? extends Payload>[] payload() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNotEmpty.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = NotEmpty.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNotEmpty {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = Null.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNull {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = Null.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachNull {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachNull.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Null;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see Null
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = Null.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachNull {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = PastOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPastOrPresent {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = PastOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPastOrPresent {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPastOrPresent.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PastOrPresent;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see PastOrPresent
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = PastOrPresent.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachPastOrPresent {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = Positive.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPositive {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = Positive.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPositive {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositive.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see Positive
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = Positive.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachPositive {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
 @EachConstraint(validateAs = PositiveOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPositiveOrZero {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
@@ -27,8 +27,7 @@ import cz.jirutka.validator.collection.CommonEachValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -37,29 +36,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @see Email
+ * @see PositiveOrZero
  * @see CommonEachValidator
  */
 @Documented
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
-@EachConstraint(validateAs = Email.class)
+@EachConstraint(validateAs = PositiveOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
-public @interface EachEmail {
+public @interface EachPositiveOrZero {
 
     String message() default "";
 
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };
-
-    /**
-     * @return an additional regular expression the annotated string must match. The default is any string ('.*')
-     */
-    String regexp() default ".*";
-
-    /**
-     * @return used in combination with {@link #regexp()} in order to specify a regular expression option
-     */
-    Pattern.Flag[] flags() default { };
 }

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachPositiveOrZero.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @EachConstraint(validateAs = PositiveOrZero.class)
 @Constraint(validatedBy = CommonEachValidator.class)
 public @interface EachPositiveOrZero {

--- a/src/main/java/cz/jirutka/validator/collection/constraints/EachSafeHtml.java
+++ b/src/main/java/cz/jirutka/validator/collection/constraints/EachSafeHtml.java
@@ -71,4 +71,11 @@ public @interface EachSafeHtml {
      * @since Hibernate Validator 5.1.0
      */
     Tag[] additionalTagsWithAttributes() default { };
+
+    /**
+     * @return Base URI used to resolve relative URIs to absolute ones. If not set, validation
+     * of HTML containing relative URIs will fail.
+     * @since Hibernate Validator 6.0.0
+     */
+    String baseURI() default "";
 }

--- a/src/main/java/cz/jirutka/validator/collection/internal/AnnotationUtils.java
+++ b/src/main/java/cz/jirutka/validator/collection/internal/AnnotationUtils.java
@@ -141,7 +141,19 @@ public abstract class AnnotationUtils {
         return createAnnotationInternal(annotationType, attributes);
     }
 
-    public static <T extends Annotation> T createAnnotationInternal(Class<T> annotationType, Map<String, Object> attributes) {
+    /**
+     * Creates an annotation instance using the respective constructor for each HV version.
+     * This is required to support both version 4.3-5.X and 6.0.0
+     *
+     * @param annotationType The annotation's class.
+     * @param attributes A map with attribute values for the annotation to be created.
+     * @param <T> The type of the annotation.
+     *
+     * @return An instance of the annotation.
+     * @throws IllegalStateException if the required constructor classes or methods are not found.
+     */
+    public static <T extends Annotation> T createAnnotationInternal(Class<T> annotationType,
+            Map<String, Object> attributes) {
         try {
             final Object descriptor;
             final Class<?> annotationDescriptorClass;

--- a/src/main/java/cz/jirutka/validator/collection/internal/AnnotationUtils.java
+++ b/src/main/java/cz/jirutka/validator/collection/internal/AnnotationUtils.java
@@ -160,7 +160,7 @@ public abstract class AnnotationUtils {
             final Class<?> annotationFactoryClass;
 
             int version = HibernateValidatorInfo.getVersion();
-            if (version >= 6_0_0) {
+            if (version >= 6_0_4) {
                 annotationDescriptorClass =
                     Class.forName("org.hibernate.validator.internal.util.annotation.AnnotationDescriptor");
                 annotationFactoryClass =

--- a/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
+++ b/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
@@ -67,22 +67,21 @@ public abstract class ConstraintDescriptorFactory {
 
         int version = HibernateValidatorInfo.getVersion();
 
-        if (version >= 6_0_0) {
+        if (version >= 6_0_4) {
             try {
                 final Class<?> descriptorClass
                     = Class.forName("org.hibernate.validator.internal.util.annotation.AnnotationDescriptor");
+                final Constructor<?> descriptorCtor = descriptorClass.getConstructor(Annotation.class);
                 return new ConstraintDescriptorFactory() {
                     Class[] getConstructorArguments() {
                         return new Class[]{ConstraintHelper.class, Member.class, descriptorClass, ElementType.class};
                     }
                     ConstraintDescriptorImpl newInstance(Annotation annotation) throws ReflectiveOperationException {
-                        final Object descriptor = descriptorClass
-                            .getConstructor(Annotation.class)
-                            .newInstance(annotation);
-                        return constructor.newInstance(CONSTRAINT_HELPER, null, descriptor, ElementType.LOCAL_VARIABLE);
+                        return constructor.newInstance(CONSTRAINT_HELPER, null, descriptorCtor.newInstance(annotation),
+                                                       ElementType.LOCAL_VARIABLE);
                     }
                 };
-            } catch (ClassNotFoundException ex) {
+            } catch (ClassNotFoundException | NoSuchMethodException ex) {
                 throw new IllegalStateException(ex);
             }
         } else if (version >= 5_1_0) {

--- a/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
+++ b/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
@@ -67,7 +67,23 @@ public abstract class ConstraintDescriptorFactory {
 
         int version = HibernateValidatorInfo.getVersion();
 
-        if (version >= 5_1_0) {
+        if (version >= 6_0_0) {
+            try {
+                final Class<?> descriptorClass
+                    = Class.forName("org.hibernate.validator.internal.util.annotation.AnnotationDescriptor");
+                return new ConstraintDescriptorFactory() {
+                    Class[] getConstructorArguments() {
+                        return new Class[]{ConstraintHelper.class, Member.class, descriptorClass, ElementType.class};
+                    }
+                    ConstraintDescriptorImpl newInstance(Annotation annotation) throws ReflectiveOperationException {
+                        final Object descriptor = descriptorClass.getConstructor(Annotation.class).newInstance(annotation);
+                        return constructor.newInstance(CONSTRAINT_HELPER, null, descriptor, ElementType.LOCAL_VARIABLE);
+                    }
+                };
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalStateException(ex);
+            }
+        } else if (version >= 5_1_0) {
             return new ConstraintDescriptorFactory() {
                 Class[] getConstructorArguments() {
                     return new Class[]{ ConstraintHelper.class, Member.class, Annotation.class, ElementType.class };

--- a/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
+++ b/src/main/java/cz/jirutka/validator/collection/internal/ConstraintDescriptorFactory.java
@@ -76,7 +76,9 @@ public abstract class ConstraintDescriptorFactory {
                         return new Class[]{ConstraintHelper.class, Member.class, descriptorClass, ElementType.class};
                     }
                     ConstraintDescriptorImpl newInstance(Annotation annotation) throws ReflectiveOperationException {
-                        final Object descriptor = descriptorClass.getConstructor(Annotation.class).newInstance(annotation);
+                        final Object descriptor = descriptorClass
+                            .getConstructor(Annotation.class)
+                            .newInstance(annotation);
                         return constructor.newInstance(CONSTRAINT_HELPER, null, descriptor, ElementType.LOCAL_VARIABLE);
                     }
                 };

--- a/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
@@ -100,7 +100,7 @@ class CommonEachValidatorIT extends Specification {
         given:
             constraint = '@EachNotBlank'
         expect:
-            assertViolations values, isValid, invalidIndex, 'must not be empty'
+            assertViolations values, isValid, invalidIndex, 'may not be empty'
         where:
             values        | desc                               || isValid | invalidIndex
             ['']          | 'value invalid by top validator'   || false   | 0

--- a/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
@@ -76,7 +76,7 @@ class CommonEachValidatorIT extends Specification {
         given:
             constraint = '@EachNotNull'
         expect:
-            assertViolations values, isValid, 1, 'must not be null'
+            assertViolations values, isValid, 1, (HV_VERSION >= 6_0_0 ? 'must' : 'may') + ' not be null'
         where:
             values      | desc              || isValid
             ['a', null] | 'a null value'    || false

--- a/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/CommonEachValidatorIT.groovy
@@ -35,6 +35,10 @@ import static cz.jirutka.validator.collection.TestUtils.validate
 @Unroll
 class CommonEachValidatorIT extends Specification {
 
+    static {
+        Locale.setDefault(new Locale("en", "US"))
+    }
+
     static HV_VERSION = HibernateValidatorInfo.getVersion()
 
     def constraint = null
@@ -72,7 +76,7 @@ class CommonEachValidatorIT extends Specification {
         given:
             constraint = '@EachNotNull'
         expect:
-            assertViolations values, isValid, 1, 'may not be null'
+            assertViolations values, isValid, 1, 'must not be null'
         where:
             values      | desc              || isValid
             ['a', null] | 'a null value'    || false
@@ -96,7 +100,7 @@ class CommonEachValidatorIT extends Specification {
         given:
             constraint = '@EachNotBlank'
         expect:
-            assertViolations values, isValid, invalidIndex, 'may not be empty'
+            assertViolations values, isValid, invalidIndex, 'must not be empty'
         where:
             values        | desc                               || isValid | invalidIndex
             ['']          | 'value invalid by top validator'   || false   | 0

--- a/src/test/groovy/cz/jirutka/validator/collection/TestUtils.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/TestUtils.groovy
@@ -23,8 +23,7 @@
  */
 package cz.jirutka.validator.collection
 
-import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor
-import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory
+import cz.jirutka.validator.collection.internal.AnnotationUtils
 
 import javax.validation.Validation
 
@@ -68,8 +67,7 @@ class TestUtils {
     }
 
     static createAnnotation(Map attributes=[:], Class annotationType) {
-        def desc = AnnotationDescriptor.getInstance(annotationType, attributes)
-        AnnotationFactory.create(desc)
+        AnnotationUtils.createAnnotationInternal(annotationType, attributes)
     }
 
     static createAnnotationString(Class annotationType, Map attributes) {

--- a/src/test/groovy/cz/jirutka/validator/collection/constraints/EachAnnotationIT.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/constraints/EachAnnotationIT.groovy
@@ -42,15 +42,15 @@ class EachAnnotationIT extends Specification {
 
     // List of @Each* annotations for constraints defined in JSR 303/349.
     static final CONSTRAINTS_JSR = [
-            EachAssertFalse, EachAssertTrue, EachDecimalMax, EachDecimalMin, EachDigits,
-            EachEmail, EachFuture, EachMax, EachMin, EachNotBlank, EachNotNull, EachNull,
-            EachPast, EachPattern, EachSize
+            EachAssertFalse, EachAssertTrue, EachDecimalMax, EachDecimalMin,
+            EachDigits, EachFuture, EachMax, EachMin, EachNotBlank, EachNotNull,
+            EachNull, EachPast, EachPattern, EachSize
     ]
 
     // List of @Each* annotations for Hibernate constraints in HV 4.3.0.
     static final CONSTRAINTS_HV = [
-            EachLength, EachNotBlank, EachNotEmpty, EachRange, EachScriptAssert,
-            EachURL
+            EachEmail, EachLength, EachNotBlank, EachNotEmpty, EachRange,
+            EachScriptAssert, EachURL
     ]
 
     // List of @Each* annotations for Hibernate constraints in HV 5.1.0 and newer.

--- a/src/test/groovy/cz/jirutka/validator/collection/constraints/EachAnnotationIT.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/constraints/EachAnnotationIT.groovy
@@ -43,9 +43,8 @@ class EachAnnotationIT extends Specification {
     // List of @Each* annotations for constraints defined in JSR 303/349.
     static final CONSTRAINTS_JSR = [
             EachAssertFalse, EachAssertTrue, EachDecimalMax, EachDecimalMin, EachDigits,
-            EachEmail, EachFuture, EachFutureOrPresent, EachMax, EachMin, EachNegative,
-            EachNegativeOrZero, EachNotBlank, EachNotNull, EachNull, EachPast,
-            EachPastOrPresent, EachPattern, EachPositive, EachPositiveOrZero, EachSize
+            EachEmail, EachFuture, EachMax, EachMin, EachNotBlank, EachNotNull, EachNull,
+            EachPast, EachPattern, EachSize
     ]
 
     // List of @Each* annotations for Hibernate constraints in HV 4.3.0.
@@ -56,13 +55,14 @@ class EachAnnotationIT extends Specification {
 
     // List of @Each* annotations for Hibernate constraints in HV 5.1.0 and newer.
     static final CONSTRAINTS_5_1_0 = [
-            EachCreditCardNumber, EachEAN, EachLuhnCheck, EachMod10Check,
-            EachMod11Check, EachSafeHtml
+            EachCreditCardNumber, EachEAN, EachLuhnCheck, EachMod10Check, EachMod11Check,
+            EachSafeHtml
     ]
 
     // List of @Each* annotations for Hibernate constraints in HV 6.0.3 and newer.
     static final CONSTRAINTS_6_0_3 = [
-            EachCodePointLength
+            EachPositive, EachPositiveOrZero, EachNegative, EachNegativeOrZero,
+            EachFutureOrPresent, EachPastOrPresent, EachCodePointLength
     ]
 
     // List of @Each* annotations which are only a composition of other @Each* annotations.

--- a/src/test/groovy/cz/jirutka/validator/collection/internal/AnnotationUtilsTest.groovy
+++ b/src/test/groovy/cz/jirutka/validator/collection/internal/AnnotationUtilsTest.groovy
@@ -41,7 +41,7 @@ class AnnotationUtilsTest extends Specification {
     def "readAttribute: return attribute's value"() {
         given:
             def attrs = value != null ? [(name): value] : [:]
-            def annotation = TestUtils.createAnnotation(Size, attrs)
+            def annotation = createAnnotationInternal(Size, attrs)
         expect:
             readAttribute(annotation, name, reqType) == expected
         where:
@@ -86,7 +86,7 @@ class AnnotationUtilsTest extends Specification {
     def 'readAllAttributes: return attributes as map'() {
         given:
             def attrs = [message: 'allons-y!', max: 10]
-            def annotation = TestUtils.createAnnotation(Size, attrs)
+            def annotation = createAnnotationInternal(Size, attrs)
             def expected = [groups: [], payload: [], min: 0] + attrs
         expect:
             readAllAttributes(annotation) == expected


### PR DESCRIPTION
This pull request adds support for hibernate-validator version 6.0.4
Legacy support is maintained as before, down to 4.3.0